### PR TITLE
Add dockerTimeout

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -4,10 +4,6 @@ FROM golang:1.15-alpine as builder
 ARG UPSTREAM_VERSION
 
 RUN apk add --no-cache make gcc musl-dev linux-headers git bash
-ADD https://golang.org/dl/go1.15.5.src.tar.gz /tmp/go.tar.gz
-RUN (cd /tmp && tar -xf go.tar.gz)
-RUN (cd /tmp/go/src && ./make.bash)
-ENV PATH="/tmp/go/bin:${PATH}"
 
 RUN git clone -b ${UPSTREAM_VERSION} https://github.com/ethereum/go-ethereum.git && \
     cd go-ethereum && make geth
@@ -19,4 +15,4 @@ RUN apk add --no-cache ca-certificates
 
 COPY --from=builder /go/go-ethereum/build/bin/geth /usr/local/bin
 
-ENTRYPOINT geth --http --http.addr 0.0.0.0 --http.corsdomain "*" --http.vhosts "*" --ws --ws.origins "*" --ws.addr 0.0.0.0 --syncmode ${SYNCMODE:-fast} --nousb $EXTRA_OPTS
+ENTRYPOINT geth --http --http.addr 0.0.0.0 --http.corsdomain "*" --http.vhosts "*" --ws --ws.origins "*" --ws.addr 0.0.0.0 --syncmode ${SYNCMODE:-fast} $EXTRA_OPTS

--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -10,6 +10,7 @@
     "linux/arm64"
   ],
   "chain": "ethereum",
+  "dockerTimeout": "5min",
   "author": "DAppNode Association <admin@dappnode.io> (https://github.com/dappnode)",
   "contributors": [
     "Mariano Conti (nanexcool) (hhttps://github.com/nanexcool)",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,18 +1,18 @@
-version: '3.4'
+version: "3.4"
 services:
   geth.dnp.dappnode.eth:
-    image: 'geth.dnp.dappnode.eth:0.1.11'
+    image: "geth.dnp.dappnode.eth:0.1.9"
     build:
       context: ./build
       args:
         UPSTREAM_VERSION: v1.9.24
     volumes:
-      - 'geth:/root/.ethereum'
+      - "geth:/root/.ethereum"
     environment:
-      - 'EXTRA_OPTS=--rpcapi eth,net,web3,txpool'
+      - "EXTRA_OPTS=--rpcapi eth,net,web3,txpool --nousb"
       - SYNCMODE
     ports:
-      - '30303'
+      - "30303"
       - 30303/udp
       - 30304/udp
     restart: always

--- a/releases.json
+++ b/releases.json
@@ -55,9 +55,9 @@
     "link": "http://my.dappnode/#/sdk/publish/r=geth.dnp.dappnode.eth&v=0.1.8&h=%2Fipfs%2FQmUf1uzqZdXyKt4YB96nr1F9GtxUWnPu8hSs7WXJnoc5Cj"
   },
   "0.1.9": {
-    "hash": "/ipfs/QmbpQoSXzPcBwm1LUeVMPosgsVUf772pN32xjDyxWnPEHT",
+    "hash": "/ipfs/QmPF4HJoNmJkoFBedv2CfVQGdPECYTmnZU3kCTodN4vkqg",
     "uploadedTo": {
-      "remote": "Fri, 07 Aug 2020 13:19:24 GMT"
+      "dappnode": "Wed, 25 Nov 2020 09:18:56 GMT"
     },
     "link": "http://my.dappnode/#/sdk/publish/r=geth.dnp.dappnode.eth&v=0.1.9&h=%2Fipfs%2FQmbpQoSXzPcBwm1LUeVMPosgsVUf772pN32xjDyxWnPEHT"
   }


### PR DESCRIPTION
What would be a sensible value for the max timeout? It should leave enough time for Geth to store pending states in memory.

**MUST** make sure that signals propagate correctly beforehand

Related to https://github.com/dappnode/DAppNodePackage-goerli-geth/pull/21
From https://github.com/dappnode/DNP_DAPPMANAGER/issues/420 