### PR TITLE
Change default syncmode to snap to prep for v1.10.14 (fast is now deprecated)

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -2,4 +2,4 @@ ARG UPSTREAM_VERSION
 
 FROM ethereum/client-go:${UPSTREAM_VERSION}
 
-ENTRYPOINT geth --http --http.addr 0.0.0.0 --http.corsdomain "*" --http.vhosts "*" --ws --ws.origins "*" --ws.addr 0.0.0.0 --syncmode ${SYNCMODE:-fast} --metrics --metrics.addr 0.0.0.0 $EXTRA_OPTIONS
+ENTRYPOINT geth --http --http.addr 0.0.0.0 --http.corsdomain "*" --http.vhosts "*" --ws --ws.origins "*" --ws.addr 0.0.0.0 --syncmode ${SYNCMODE:-snap} --metrics --metrics.addr 0.0.0.0 $EXTRA_OPTIONS


### PR DESCRIPTION
old default syncmode (Fast Bloom) has been deprecated in upstream v1.10.14 and needs to be changed for the new version to work.