### PR TITLE
FIx ubuntu machine on build test

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build-test:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     name: Build test
     if: github.event_name == 'push' || github.event_name == 'repository_dispatch'
     steps:


### PR DESCRIPTION
The build test is done on ubuntu 16.04, the are not many machines with this so and sometimes the build gives an error because it does not find a machine