### PR TITLE
Fix wrong EXTRA_OPTIONS string

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     volumes:
       - "geth:/root/.ethereum"
     environment:
-      - "EXTRA_OPTIONS=--http.api eth,net,web3,txpool eth,net,web3,txpool"
+      - "EXTRA_OPTIONS=--http.api eth,net,web3,txpool"
       - SYNCMODE=snap
     ports:
       - 30303/tcp


### PR DESCRIPTION
Hey,

in the last release it seems that might have accidentaly broke the package.

I removed the broken part of the string in this PR. Also, disabling a feature (ws) that was enabled by default should probably be communicated beforehand. Multiple users have complained in discord. :(

<img width="346" alt="image" src="https://user-images.githubusercontent.com/12911176/161436785-91ce2b70-758b-4994-9517-fe9f0c8c934d.png">
