### PR TITLE
Bumped version for Gray Glacier hard fork

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,7 +1,7 @@
 {
   "name": "geth.dnp.dappnode.eth",
-  "version": "0.1.17",
-  "upstreamVersion": "v1.10.18",
+  "version": "0.1.19",
+  "upstreamVersion": "v1.10.19",
   "upstreamRepo": "ethereum/go-ethereum",
   "upstreamArg": "UPSTREAM_VERSION",
   "shortDescription": "Geth is the official Go implementation of the Ethereum protocol.",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,11 @@
 version: "3.4"
 services:
   geth.dnp.dappnode.eth:
-    image: "geth.dnp.dappnode.eth:0.1.17"
+    image: "geth.dnp.dappnode.eth:0.1.19"
     build:
       context: .
       args:
-        UPSTREAM_VERSION: v1.10.18
+        UPSTREAM_VERSION: v1.10.19
     volumes:
       - "geth:/root/.ethereum"
     environment:


### PR DESCRIPTION
Impromptu-release from the Geth team in preparation for the Gray Glacier hard fork that pushes the difficulty bomb further away (ETA June 29th). Should get this out to the public as soon as possible. 

[v.1.10.19 Changelog on Github](https://github.com/ethereum/go-ethereum/releases/tag/v1.10.19)