### PR TITLE
Fix port

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,11 +10,11 @@ services:
       - "geth:/root/.ethereum"
     environment:
       - "EXTRA_OPTION=--http.api eth,engine,net,web3,txpool"
-      - P2P_PORT=30304
+      - P2P_PORT=30403
       - SYNCMODE=snap
     ports:
-      - "30304:30304/tcp"
-      - "30304:30304/udp"
+      - "30403:30403/tcp"
+      - "30403:30403/udp"
     restart: unless-stopped
 volumes:
   geth: {}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,8 +13,8 @@ services:
       - P2P_PORT=30304
       - SYNCMODE=snap
     ports:
-      - "30313:30313/tcp"
-      - "30313:30313/udp"
+      - "30304:30304/tcp"
+      - "30304:30304/udp"
     restart: unless-stopped
 volumes:
   geth: {}


### PR DESCRIPTION
The p2p ports are not the same, and they use the number that is not in the https://github.com/dappnode/DAppNode/issues/457. This happened because we changed the criteria.