### PR TITLE
Change env var name

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ COPY jwtsecret.hex /jwtsecret
 
 ENTRYPOINT geth --http --http.addr 0.0.0.0 \
   --http.corsdomain "*" --http.vhosts "*" \
-  --syncmode ${SYNCMODE:-snap} --port ${P2P_PORT} \
+  --syncmode ${SYNCMODE:-snap} --port ${P2P_PORTS} \
   --metrics --metrics.addr 0.0.0.0 \
   --authrpc.addr 0.0.0.0 \
   --authrpc.port 8551 \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       - "geth:/root/.ethereum"
     environment:
       - "EXTRA_OPTION=--http.api eth,engine,net,web3,txpool"
-      - P2P_PORT=30403
+      - P2P_PORTS=30403
       - SYNCMODE=snap
     ports:
       - "30403:30403/tcp"


### PR DESCRIPTION
We modified the ports of geth but the value of the env is not changed if you have installed geth from before, so the most easiest way to force the change of the port is to change the name of the env var, so the var value will update for all the dappnodes.