### PR TITLE
Bump upstream for v1.11.5 for Shanghai

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,7 +1,7 @@
 {
   "name": "geth.dnp.dappnode.eth",
   "version": "0.1.38",
-  "upstreamVersion": "v1.11.1",
+  "upstreamVersion": "v1.11.5",
   "upstreamRepo": "ethereum/go-ethereum",
   "upstreamArg": "UPSTREAM_VERSION",
   "shortDescription": "Geth is the official Go implementation of the Ethereum protocol.",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     build:
       context: .
       args:
-        UPSTREAM_VERSION: v1.11.1
+        UPSTREAM_VERSION: v1.11.5
     volumes:
       - "geth:/root/.ethereum"
     environment:


### PR DESCRIPTION
v1.11.5 is required for mainnet Shanghai. Need to merge as soon as tested. 